### PR TITLE
Fix: Localization starts with placeholder

### DIFF
--- a/PhraseSwift.podspec
+++ b/PhraseSwift.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PhraseSwift'
-  s.version          = '0.1.1'
+  s.version          = '0.1.2'
   s.summary          = 'A swift port of Squares Phrase library.'
 
 # This description is used to generate tags and improve search results.

--- a/PhraseSwift/PhraseSwift/Phrase.swift
+++ b/PhraseSwift/PhraseSwift/Phrase.swift
@@ -62,7 +62,7 @@ public final class Phrase {
             
             // Copy the original pattern to preserve all spans, such as bold, italic, etc.
             let sb = NSMutableAttributedString(string: pattern)
-            while let t = head?.next {
+            while let t = head {
                 t.expand(target: sb, data: keysToValue)
                 head = head!.next
             }

--- a/PhraseSwift/PhraseSwiftTests/PhraseSwiftTests.swift
+++ b/PhraseSwift/PhraseSwiftTests/PhraseSwiftTests.swift
@@ -102,6 +102,19 @@ class PhraseSwiftTests: XCTestCase {
         XCTAssert(secondOutput == "Two is better than one.")
     }
     
+    func testEndsWithKeyLocalization() {
+        let firstOutput = Phrase(pattern: "PhraseSwift is {stupid}")
+            .put(key: "stupid", value: "awesome")
+            .format()
+        XCTAssert(firstOutput == "PhraseSwift is awesome")
+        
+        let secondOutput = Phrase(pattern: "{one} is better than {two}")
+            .put(key: "one", value: "Two")
+            .put(key: "two", value: "one")
+            .format()
+        XCTAssert(secondOutput == "Two is better than one")
+    }
+    
     func testSpacedKeyLocalization() {
         let firstOutput = Phrase(pattern: "Hi, this is a {key one} test with {key two} keys.")
             .put(key: "key two", value: "multiple")

--- a/PhraseSwift/PhraseSwiftTests/PhraseSwiftTests.swift
+++ b/PhraseSwift/PhraseSwiftTests/PhraseSwiftTests.swift
@@ -89,6 +89,19 @@ class PhraseSwiftTests: XCTestCase {
         XCTAssert(secondOutput == "Hi, Hope you {second} it")
     }
     
+    func testStartsWithKeyLocalization() {
+        let firstOutput = Phrase(pattern: "{key} is awesome!")
+            .put(key: "key", value: "PhraseSwift")
+            .format()
+        XCTAssert(firstOutput == "PhraseSwift is awesome!")
+        
+        let secondOutput = Phrase(pattern: "{one} is better than {two}.")
+            .put(key: "one", value: "Two")
+            .put(key: "two", value: "one")
+            .format()
+        XCTAssert(secondOutput == "Two is better than one.")
+    }
+    
     func testSpacedKeyLocalization() {
         let firstOutput = Phrase(pattern: "Hi, this is a {key one} test with {key two} keys.")
             .put(key: "key two", value: "multiple")


### PR DESCRIPTION
The port had an issue when a localization string starts with a placeholder, for example:
```
let firstOutput = Phrase(pattern: "{key} is awesome!")
    .put(key: "key", value: "PhraseSwift")
    .format()
```
I created tests for patterns starting and ending with parameters and fixed the bug.

The problem was that the first element from the pattern was simply skipped in the expansion loop.