### PR TITLE
Fix memory leaks due to double linked list

### DIFF
--- a/PhraseSwift.podspec
+++ b/PhraseSwift.podspec
@@ -7,7 +7,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'PhraseSwift'
-  s.version          = '0.1.2'
+  s.version          = '0.1.3'
   s.summary          = 'A swift port of Squares Phrase library.'
 
 # This description is used to generate tags and improve search results.

--- a/PhraseSwift/PhraseSwift/Phrase.swift
+++ b/PhraseSwift/PhraseSwift/Phrase.swift
@@ -65,6 +65,7 @@ public final class Phrase {
             while let t = head {
                 t.expand(target: sb, data: keysToValue)
                 head = head!.next
+                t.next = nil // Release the reference after it has been expanded
             }
             formatted = sb.string
             


### PR DESCRIPTION
### What?
Fix memory leaks for phrases with placeholders due to double linked list.

### Why?
Reduce memory overload. Before, any phrase with placeholders created a retain cycle because the items of the double linked list hold strong reference to the previous and next item.

### How?
Release the reference to the next item after its value has been expanded (and printed into the resulting string) to prevent memory leaks

### Testing?
All test cases of the project pass; tested in memory debugger that the memory leaks are not showing up any more.